### PR TITLE
Removes resilience argument post mirai 1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: future.mirai
-Version: 0.2.1
+Version: 0.2.1.9000
 Depends:
     future
 Imports:
-    mirai (>= 0.12.1),
+    mirai (>= 1.1.0),
     parallelly,
     utils
 Suggests:

--- a/R/MiraiFuture-class.R
+++ b/R/MiraiFuture-class.R
@@ -58,7 +58,7 @@ MiraiFuture <- function(expr = NULL,
       daemons(n = 0L)
     } else if (workers != nworkers) {
       daemons(n = 0L)  ## reset is required
-      daemons(n = workers, dispatcher = dispatcher, resilience = FALSE)
+      daemons(n = workers, dispatcher = dispatcher)
     }
   } else if (!is.null(workers)) {
     stop("Argument 'workers' should be a numeric scalar or NULL: ", mode(workers))


### PR DESCRIPTION
There is no longer a 'resilience' argument at `daemons()`.

Now behaviour is _always_ `resilience = FALSE` so you no longer need to specify this manually.

Thanks.